### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ The array is a VGroup, so you can transform it as a whole.
 
  .. code-block:: python
 
-    self.play(array.scale, 1.1, run_time=0.5)
+    self.play(ApplyMethod(array.scale, 1.1), run_time=0.5)
 
 Popping an element:
 


### PR DESCRIPTION
Without `ApplyMethod` the third example, which is supposed to scale the array, generates a TypeError: Passing Mobject methods to Scene.play is no longer supported. Use Mobject.animate instead.